### PR TITLE
remove dataPtr support from dpiData_setBytes

### DIFF
--- a/c_src/dpiData_nif.c
+++ b/c_src/dpiData_nif.c
@@ -203,14 +203,9 @@ DPI_NIF_FUN(data_setBytes)
     CHECK_ARGCOUNT(2);
 
     dpiData_res *dataRes = NULL;
-    dpiDataPtr_res *dataPtr = NULL;
     dpiData *data = NULL;
 
-    if (enif_get_resource(env, argv[0], dpiDataPtr_type, (void **)&dataPtr))
-    {
-        data = dataPtr->dpiDataPtr;
-    }
-    else if (enif_get_resource(env, argv[0], dpiData_type, (void **)&dataRes))
+    if (enif_get_resource(env, argv[0], dpiData_type, (void **)&dataRes))
     {
         data = &dataRes->dpiData;
     }


### PR DESCRIPTION
remove the "ability" to call `dpiData_setBytes` using a `dataPtr` (data carrier for `dpiVar`)
`dpiVar_setFromBytes` should be used instead

Official Documentation: [`dpiData_setBytes`](https://oracle.github.io/odpi/doc/functions/dpiData.html#c.dpiData_setBytes)
> ... Do not use this function when setting data for variables. Instead, use the function dpiVar_setFromBytes().