### PR TITLE
eunit fixes and improvements

### DIFF
--- a/c_src/dpiContext_nif.c
+++ b/c_src/dpiContext_nif.c
@@ -33,9 +33,10 @@ DPI_NIF_FUN(context_create)
         RETURNED_TRACE;
         return enif_raise_exception(
             env,
-            enif_make_tuple2(
+            enif_make_tuple4(
                 env, ATOM_ERROR,
-                dpiErrorInfoMap(env, error)));
+                enif_make_string(env, __FILE__, ERL_NIF_LATIN1),
+                enif_make_int(env, __LINE__), dpiErrorInfoMap(env, error)));
     }
 
     ERL_NIF_TERM contextResTerm = enif_make_resource(env, contextRes);

--- a/c_src/dpi_nif.h
+++ b/c_src/dpi_nif.h
@@ -99,14 +99,15 @@
 #define RAISE_STR_EXCEPTION(__EB) \
     RAISE_EXCEPTION(enif_make_string(env, (const char *)(__EB), ERL_NIF_LATIN1))
 
-#define RAISE_EXCEPTION(__T)                                                      \
-    {                                                                             \
-        RETURNED_TRACE;                                                           \
-        return enif_raise_exception(                                              \
-            env,                                                                  \
-            enif_make_tuple4(                                                     \
-                env, ATOM_ERROR, enif_make_string(env, __FILE__, ERL_NIF_LATIN1), \
-                enif_make_int(env, __LINE__), (__T)));                            \
+#define RAISE_EXCEPTION(__T)                                     \
+    {                                                            \
+        RETURNED_TRACE;                                          \
+        return enif_raise_exception(                             \
+            env,                                                 \
+            enif_make_tuple4(                                    \
+                env, ATOM_ERROR,                                 \
+                enif_make_string(env, __FILE__, ERL_NIF_LATIN1), \
+                enif_make_int(env, __LINE__), (__T)));           \
     }
 
 #define CHECK_ARGCOUNT(_Count)                               \

--- a/test/oranif_eunit.erl
+++ b/test/oranif_eunit.erl
@@ -24,6 +24,10 @@
 -define(W(_Tests), fun(__Ctx) -> _Tests end).
 -define(F(__Fn), {??__Fn, fun() -> __Fn(__Ctx) end}).
 
+-define(ASSERT_EX(_Error, _Expern),
+    ?assertException(error, {error, _File, _Line, _Error}, _Expern)
+).
+
 %-------------------------------------------------------------------------------
 % Context APIs
 %-------------------------------------------------------------------------------
@@ -36,21 +40,21 @@ contextCreate(TestCtx) ->
     dpiCall(TestCtx, context_destroy, [Context]).
 
 contextCreateBadMaj(TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve uint major from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint major from arg0",
         dpiCall(TestCtx, context_create, [?BAD_INT, ?DPI_MINOR_VERSION])
     ).
 
 contextCreateBadMin(TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve uint minor from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint minor from arg1",
         dpiCall(TestCtx, context_create, [?DPI_MAJOR_VERSION, ?BAD_INT])
     ).
 
 % fails due to nonsense major version
 contextCreateFail(TestCtx) ->
-    ?assertException(
-        error, {error, _},
+    ?ASSERT_EX(
+        #{},
         dpiCall(TestCtx, context_create, [1337, ?DPI_MINOR_VERSION])
     ).
 
@@ -61,9 +65,8 @@ contextDestroy(TestCtx) ->
     ?assertEqual(ok, dpiCall(TestCtx, context_destroy, [Context])).
 
 contextDestroyBadContext(TestCtx) ->
-   ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource context from arg0"},
+   ?ASSERT_EX(
+       "Unable to retrieve resource context from arg0",
         dpiCall(TestCtx, context_destroy, [?BAD_REF])).
 
 contextDestroyBadContextState(TestCtx) ->
@@ -73,8 +76,8 @@ contextDestroyBadContextState(TestCtx) ->
     % destroy the context
     ?assertEqual(ok, dpiCall(TestCtx, context_destroy, [Context])),
     % try to destroy it again
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(TestCtx, context_destroy, [Context])
     ).
 
@@ -93,9 +96,8 @@ contextGetClientVersionBadContext(TestCtx) ->
     Context = dpiCall(
         TestCtx, context_create, [?DPI_MAJOR_VERSION, ?DPI_MINOR_VERSION]
     ),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource context from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource context from arg0",
         dpiCall(TestCtx, context_getClientVersion, [?BAD_REF])
     ),
     dpiCall(TestCtx, context_destroy, [Context]).
@@ -103,8 +105,8 @@ contextGetClientVersionBadContext(TestCtx) ->
 % fails due to a wrong handle being passed
 contextGetClientVersionFail(TestCtx) ->
     BindData = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource context from arg0",
         dpiCall(TestCtx, context_getClientVersion, [BindData])
     ),
     dpiCall(TestCtx, data_release, [BindData]).
@@ -122,9 +124,8 @@ connCreate(#{context := Context} = TestCtx) ->
 
 connCreateBadContext(TestCtx) ->
     #{tns := Tns, user := User, password := Password} = getConfig(),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource context from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource context from arg0",
         dpiCall(
             TestCtx, conn_create, [
                 ?BAD_REF, User, Password, Tns,
@@ -135,8 +136,8 @@ connCreateBadContext(TestCtx) ->
 
 connCreateBadUsername(#{context := Context} = TestCtx) ->
     #{tns := Tns, user := _User, password := Password} = getConfig(),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve string/binary userName from arg1",
         dpiCall(
             TestCtx, conn_create,
             [Context, badBin, Password, Tns,
@@ -146,8 +147,8 @@ connCreateBadUsername(#{context := Context} = TestCtx) ->
 
 connCreateBadPass(#{context := Context} = TestCtx) ->
     #{tns := Tns, user := User, password := _Password} = getConfig(),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve string/binary password from arg2",
         dpiCall(
             TestCtx, conn_create,
             [Context, User, badBin, Tns,
@@ -157,8 +158,8 @@ connCreateBadPass(#{context := Context} = TestCtx) ->
 
 connCreateBadTNS(#{context := Context} = TestCtx) ->
     #{tns := _Tns, user := User, password := Password} = getConfig(),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve string/binary connectString from arg3",
         dpiCall(
             TestCtx, conn_create,
                 [Context, User, Password, badBin,
@@ -168,8 +169,8 @@ connCreateBadTNS(#{context := Context} = TestCtx) ->
 
 connCreateBadParams(#{context := Context} = TestCtx) ->
     #{tns := Tns, user := User, password := Password} = getConfig(),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve map commonParams from arg4",
         dpiCall(
             TestCtx, conn_create, [Context, User, Password, Tns, badMap, #{}]
         )
@@ -177,8 +178,8 @@ connCreateBadParams(#{context := Context} = TestCtx) ->
 
 connCreateBadEncoding(#{context := Context} = TestCtx) ->
     #{tns := Tns, user := User, password := Password} = getConfig(),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve string",
         dpiCall(
             TestCtx, conn_create, [Context, User, Password, Tns,
                 #{encoding =>badList, nencoding => "AL32UTF8"}, #{}]
@@ -187,8 +188,8 @@ connCreateBadEncoding(#{context := Context} = TestCtx) ->
 
 connCreateBadNencoding(#{context := Context} = TestCtx) ->
     #{tns := Tns, user := User, password := Password} = getConfig(),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve string",
         dpiCall(
             TestCtx, conn_create,
             [Context, User, Password, Tns,
@@ -198,9 +199,9 @@ connCreateBadNencoding(#{context := Context} = TestCtx) ->
 
 % fails due to invalid user/pass combination
 connCreateFail(#{context := Context} = TestCtx) ->
-    #{tns := Tns, user := User, password := Password} = getConfig(),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    #{tns := Tns} = getConfig(),
+    ?ASSERT_EX(
+        #{},
         dpiCall(
             TestCtx, conn_create,
             [Context, <<"Chuck">>, <<"Norris">>, Tns,
@@ -221,32 +222,30 @@ connPrepareStmtEmptyTag(#{session := Conn} = TestCtx) ->
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
 connPrepareStmtBadConn(TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource connection from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(
             TestCtx, conn_prepareStmt, [?BAD_REF, false, <<"miau">>, <<>>]
         )
     ).
 
 connPrepareStmtBadScrollable(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve bool/atom scrollable from arg1",
         dpiCall(
             TestCtx, conn_prepareStmt, [Conn, "badAtom", <<"miau">>, <<>>]
         )
     ).
 
 connPrepareStmtBadSQL(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve binary/string sql from arg2",
         dpiCall(TestCtx, conn_prepareStmt, [Conn, false, badBinary, <<>>])
     ).
 
 connPrepareStmtBadTag(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve binary/string tag from arg3",
         dpiCall(
             TestCtx, conn_prepareStmt, [Conn, false, <<"miau">>, badBinary]
         )
@@ -254,8 +253,8 @@ connPrepareStmtBadTag(#{session := Conn} = TestCtx) ->
 
 % fails due to both SQL and Tag being empty
 connPrepareStmtFail(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(TestCtx, conn_prepareStmt, [Conn, false, <<>>, <<>>])
     ).
 
@@ -272,11 +271,9 @@ connNewVar(#{session := Conn} = TestCtx) ->
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
     dpiCall(TestCtx, var_release, [Var]).
 
-connNewVarBadConn(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource connection from arg0"},
+connNewVarBadConn(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(
             TestCtx, conn_newVar, 
             [?BAD_REF, 'DPI_ORACLE_TYPE_NATIVE_DOUBLE',
@@ -285,8 +282,8 @@ connNewVarBadConn(#{session := Conn} = TestCtx) ->
     ).
 
 connNewVarBadOraType(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(
             TestCtx, conn_newVar, 
             [Conn, "badAtom", 'DPI_NATIVE_TYPE_DOUBLE', 100, 0, false, false,
@@ -295,8 +292,8 @@ connNewVarBadOraType(#{session := Conn} = TestCtx) ->
     ).
 
 connNewVarBadDpiType(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "wrong or unsupported dpiNativeType type",
         dpiCall(
             TestCtx, conn_newVar, 
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_DOUBLE', "badAtom", 100, 0, false,
@@ -305,9 +302,8 @@ connNewVarBadDpiType(#{session := Conn} = TestCtx) ->
     ).
 
 connNewVarBadArraySize(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint size from arg3"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint size from arg3",
         dpiCall(
             TestCtx, conn_newVar, 
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_DOUBLE', 'DPI_NATIVE_TYPE_DOUBLE',
@@ -316,9 +312,8 @@ connNewVarBadArraySize(#{session := Conn} = TestCtx) ->
     ).
 
 connNewVarBadSize(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint size from arg4"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint size from arg4",
         dpiCall(
             TestCtx, conn_newVar, 
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_DOUBLE', 'DPI_NATIVE_TYPE_DOUBLE', 
@@ -327,8 +322,8 @@ connNewVarBadSize(#{session := Conn} = TestCtx) ->
     ).
 
 connNewVarBadSizeIsBytes(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve atom sizeIsBytes from arg5",
         dpiCall(
             TestCtx, conn_newVar, 
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_DOUBLE', 'DPI_NATIVE_TYPE_DOUBLE',
@@ -337,8 +332,8 @@ connNewVarBadSizeIsBytes(#{session := Conn} = TestCtx) ->
     ).
 
 connNewVarBadArray(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve atom isArray from arg6",
         dpiCall(
             TestCtx, conn_newVar, 
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_DOUBLE', 'DPI_NATIVE_TYPE_DOUBLE',
@@ -347,8 +342,8 @@ connNewVarBadArray(#{session := Conn} = TestCtx) ->
     ).
 
 connNewVarBadObjType(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve atom objType from arg7",
         dpiCall(
             TestCtx, conn_newVar,
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_DOUBLE', 'DPI_NATIVE_TYPE_DOUBLE',
@@ -358,8 +353,8 @@ connNewVarBadObjType(#{session := Conn} = TestCtx) ->
 
 % fails due to array size being 0
 connNewVarFail(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(
             TestCtx, conn_newVar,
                 [Conn, 'DPI_ORACLE_TYPE_NATIVE_DOUBLE',
@@ -371,18 +366,16 @@ connCommit(#{session := Conn} = TestCtx) ->
     Result = dpiCall(TestCtx, conn_commit, [Conn]),
     ?assertEqual(ok, Result).
   
-connCommitBadConn(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource connection from arg0"},
+connCommitBadConn(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_commit, [?BAD_REF])
     ).
 
 % fails due to the reference being wrong
 connCommitFail(#{context := Context} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_commit, [Context])
     ).
 
@@ -390,18 +383,16 @@ connRollback(#{session := Conn} = TestCtx) ->
     Result = dpiCall(TestCtx, conn_rollback, [Conn]),
     ?assertEqual(ok, Result).
   
-connRollbackBadConn(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource connection from arg0"},
+connRollbackBadConn(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_rollback, [?BAD_REF])
     ).
 
 % fails due to the reference being wrong
 connRollbackFail(#{context := Context} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_rollback, [Context])
     ).
 
@@ -409,17 +400,15 @@ connPing(#{session := Conn} = TestCtx) ->
     Result = dpiCall(TestCtx, conn_ping, [Conn]),
     ?assertEqual(ok, Result).
   
-connPingBadConn(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource connection from arg0"},
+connPingBadConn(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_ping, [?BAD_REF])).
 
 % fails due to the reference being wrong
 connPingFail(#{context := Context} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_ping, [Context])
     ).
 
@@ -444,42 +433,40 @@ connCloseWithModes(#{context := Context} = TestCtx) ->
     ),
     ?assertEqual(ok, Result).
   
-connCloseBadConn(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource connection from arg0"},
+connCloseBadConn(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_close, [?BAD_REF, [], <<>>])
     ).
 
 connCloseBadModes(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve atom list modes, not a list from arg1",
         dpiCall(TestCtx, conn_close, [Conn, badList, <<>>])
     ).
 
 connCloseBadModesInside(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve mode list value from arg1",
         dpiCall(TestCtx, conn_close, [Conn, ["badAtom"], <<>>])
     ).
 
 connCloseInvalidMode(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve DPI_MODE atom from arg1",
         dpiCall(TestCtx, conn_close, [Conn, [wrongAtom], <<>>])
     ).
 
 connCloseBadTag(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve binary/string tag from arg2",
         dpiCall(TestCtx, conn_close, [Conn, [], badBinary])
     ).
 
 % fails due to the reference being wrong
 connCloseFail(#{context := Context} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_close, [Context, [], <<>>])
     ).
 
@@ -496,11 +483,9 @@ connGetServerVersion(#{session := Conn} = TestCtx) ->
     ?assert(is_integer(PortUpdateNum)),
     ?assert(is_list(ReleaseString)).
   
-connGetServerVersionBadConn(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource connection from arg0"},
+connGetServerVersionBadConn(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_getServerVersion, [?BAD_REF])
     ).
 
@@ -511,8 +496,8 @@ connGetServerVersionFail(#{context := Context} = TestCtx) ->
     Conn = dpiCall(TestCtx, conn_create, [Context, User, Password, Tns,
             #{encoding => "AL32UTF8", nencoding => "AL32UTF8"}, #{}]),
     dpiCall(TestCtx, conn_close, [Conn, [], <<>>]),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(TestCtx, conn_getServerVersion, [Context])
     ).
 
@@ -525,10 +510,8 @@ connSetClientIdentifier(#{session := Conn} = TestCtx) ->
     ).
 
 connSetClientIdentifierBadConn(TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, 
-            "Unable to retrieve resource connection from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource connection from arg0",
         dpiCall(
             TestCtx, conn_setClientIdentifier,
             [?BAD_REF, <<"myCoolConnection">>]
@@ -536,10 +519,8 @@ connSetClientIdentifierBadConn(TestCtx) ->
     ).
 
 connSetClientIdentifierBadValue(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, 
-            "Unable to retrieve string/binary value from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve string/binary value from arg1",
         dpiCall(
             TestCtx, conn_setClientIdentifier, [Conn, badBinary]
         )
@@ -569,11 +550,9 @@ stmtExecuteWithModes(#{session := Conn} = TestCtx) ->
     ?assertEqual(1, QueryCols),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
-stmtExecutebadStmt(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+stmtExecutebadStmt(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_execute, [?BAD_REF, []])
     ).
 
@@ -582,8 +561,8 @@ stmtExecuteBadModes(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt, 
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve atom list modes, not a list from arg1",
         dpiCall(TestCtx, stmt_execute, [Stmt, badList])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
@@ -593,20 +572,20 @@ stmtExecuteBadModesInside(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt, 
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Mode is list from arg is not atom",
         dpiCall(TestCtx, stmt_execute, [Stmt, ["badAtom"]])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
 % fails due to the SQL being invalid
-stmtExecuteFail(#{session := Conn, context := Context} = TestCtx) ->
+stmtExecuteFail(#{session := Conn} = TestCtx) ->
     Stmt = dpiCall(
         TestCtx, conn_prepareStmt, 
         [Conn, false, <<"all your base are belong to us">>, <<>>]
     ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(TestCtx, stmt_execute, [Stmt, []])
     ).
 
@@ -620,22 +599,16 @@ stmtFetch(#{session := Conn} = TestCtx) ->
     ?assert(is_integer(BufferRowIndex)),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
-stmtFetchBadStmt(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+stmtFetchBadStmt(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_fetch, [?BAD_REF])
     ).
 
 % fails due to the reference being of the wrong type
-stmtFetchFail(#{session := Conn, context := Context} = TestCtx) ->
-    Stmt = dpiCall(
-        TestCtx, conn_prepareStmt, 
-        [Conn, false, <<"insert into test_dpi (a) values (1337)">>, <<>>]
-    ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+stmtFetchBadRes(#{session := Conn} = TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_fetch, [Conn])
     ).
 
@@ -653,11 +626,9 @@ stmtGetQueryValue(#{session := Conn} = TestCtx) ->
     dpiCall(TestCtx, data_release, [Result]),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
-stmtGetQueryValueBadStmt(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+stmtGetQueryValueBadStmt(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_getQueryValue, [?BAD_REF, 1])
     ).
 
@@ -666,9 +637,8 @@ stmtGetQueryValueBadPos(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt, 
         [Conn, false, <<"select 1337 from dual">>, <<>>]
     ),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint pos from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(TestCtx, stmt_getQueryValue, [Stmt, ?BAD_INT])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
@@ -680,8 +650,8 @@ stmtGetQueryValueFail(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"select 1337 from dual">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(TestCtx, stmt_getQueryValue, [Stmt, 1])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
@@ -696,11 +666,9 @@ stmtGetQueryInfo(#{session := Conn} = TestCtx) ->
     dpiCall(TestCtx, queryInfo_delete, [Info]),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
-stmtGetQueryInfoBadStmt(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+stmtGetQueryInfoBadStmt(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_getQueryInfo, [?BAD_REF, 1])
     ).
 
@@ -710,9 +678,8 @@ stmtGetQueryInfoBadPos(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"select 1337 from dual">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint pos from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(TestCtx, stmt_getQueryInfo, [Stmt, ?BAD_INT])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
@@ -723,8 +690,8 @@ stmtGetQueryInfoFail(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt, 
         [Conn, false, <<"bibidi babidi boo">>, <<>>]
     ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(TestCtx, stmt_getQueryInfo, [Stmt, 1])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
@@ -738,11 +705,9 @@ stmtGetNumQueryColumns(#{session := Conn} = TestCtx) ->
     ?assert(is_integer(Count)),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
-stmtGetNumQueryColumnsBadStmt(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+stmtGetNumQueryColumnsBadStmt(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_getNumQueryColumns, [?BAD_REF])
     ).
 
@@ -752,8 +717,8 @@ stmtGetNumQueryColumnsFail(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt, [Conn, false, <<"it is showtime">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(TestCtx, stmt_getNumQueryColumns, [Stmt])
     ).
 
@@ -775,12 +740,10 @@ stmtBindValueByPos(#{session := Conn} = TestCtx) ->
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]),
     ?EXEC_STMT(Conn, <<"drop table test_dpi">>).
 
-stmtBindValueByPosBadStmt(#{session := Conn} = TestCtx) -> 
+stmtBindValueByPosBadStmt(TestCtx) -> 
     BindData = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(
             TestCtx, stmt_bindValueByPos,
             [?BAD_REF, 1, 'DPI_NATIVE_TYPE_INT64', BindData]
@@ -794,9 +757,8 @@ stmtBindValueByPosBadPos(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
     BindData = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint pos from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(
             TestCtx, stmt_bindValueByPos,
             [Stmt, ?BAD_INT, 'DPI_NATIVE_TYPE_INT64', BindData]
@@ -811,8 +773,8 @@ stmtBindValueByPosBadType(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
     BindData = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "wrong or unsupported dpiNativeType type",
         dpiCall(TestCtx, stmt_bindValueByPos, [Stmt, 1, "badAtom", BindData])
     ),
     dpiCall(TestCtx, data_release, [BindData]),
@@ -823,9 +785,8 @@ stmtBindValueByPosBadData(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt, 
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data from arg3"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data from arg3",
         dpiCall(
             TestCtx, stmt_bindValueByPos, 
             [Stmt, 1, 'DPI_NATIVE_TYPE_INT64', ?BAD_REF]
@@ -842,8 +803,8 @@ stmtBindValueByPosFail(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
     BindData = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(
             TestCtx, stmt_bindValueByPos, 
             [Stmt, -1, 'DPI_NATIVE_TYPE_INT64', BindData]
@@ -871,12 +832,10 @@ stmtBindValueByName(#{session := Conn} = TestCtx) ->
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]),
     ?EXEC_STMT(Conn, <<"drop table test_dpi">>).
 
-stmtBindValueByNameBadStmt(#{session := Conn} = TestCtx) -> 
+stmtBindValueByNameBadStmt(TestCtx) -> 
     BindData = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(
             TestCtx, stmt_bindValueByName, 
             [?BAD_REF, <<"A">>, 'DPI_NATIVE_TYPE_INT64', BindData]
@@ -890,9 +849,8 @@ stmtBindValueByNameBadPos(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
     BindData = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve string/list name from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve string/list name from arg1",
         dpiCall(
             TestCtx, stmt_bindValueByName,
             [Stmt, ?BAD_INT, 'DPI_NATIVE_TYPE_INT64', BindData]
@@ -907,8 +865,8 @@ stmtBindValueByNameBadPosType(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
     BindData = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "wrong or unsupported dpiNativeType type",
         dpiCall(
             TestCtx, stmt_bindValueByName, [Stmt, <<"A">>, "badAtom", BindData])
         ),
@@ -920,9 +878,8 @@ stmtBindValueByNameBadData(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt, 
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data from arg3"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data from arg3",
         dpiCall(
             TestCtx, stmt_bindValueByName, 
             [Stmt, <<"A">>, 'DPI_NATIVE_TYPE_INT64', ?BAD_REF]
@@ -939,8 +896,8 @@ stmtBindValueByNameFail(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
     BindData = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data from arg3",
         dpiCall(
             TestCtx, stmt_bindValueByName, 
             [Stmt, <<"A">>, 'DPI_NATIVE_TYPE_INT64', Stmt]
@@ -978,10 +935,8 @@ stmtBindByPosBadStmt(#{session := Conn} = TestCtx) ->
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64', 100,
                 0, false, false, null]
         ),
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_bindByPos, [?BAD_REF, 1, Var])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1001,9 +956,8 @@ stmtBindByPosBadPos(#{session := Conn} = TestCtx) ->
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64',
             100, 0, false, false, null]
         ),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint pos from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(TestCtx, stmt_bindByPos, [Stmt, ?BAD_INT, Var])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1018,9 +972,8 @@ stmtBindByPosBadVar(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt,
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource var from arg3"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource var from arg3",
         dpiCall(TestCtx, stmt_bindByPos, [Stmt, 1, ?BAD_REF])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]),
@@ -1040,8 +993,8 @@ stmtBindByPosFail(#{session := Conn} = TestCtx) ->
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64', 100,
             0, false, false, null]
         ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(TestCtx, stmt_bindByPos, [Stmt, -1, Var])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1077,10 +1030,8 @@ stmtBindByNameBadStmt(#{session := Conn} = TestCtx) ->
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64',
                 100, 0, false, false, null]
         ),
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_bindByName, [?BAD_REF, <<"A">>, Var])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1100,8 +1051,8 @@ stmtBindByNameBadPos(#{session := Conn} = TestCtx) ->
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64', 100,
                 0, false, false, null]
         ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve string/list name from arg1",
         dpiCall(TestCtx, stmt_bindByName, [Stmt, badBinary, Var])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1116,9 +1067,8 @@ stmtBindByNameBadVar(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt,
         [Conn, false, <<"insert into test_dpi values (:A)">>, <<>>]
     ),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource var from arg3"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource var from arg3",
         dpiCall(TestCtx, stmt_bindByName, [Stmt, <<"A">>, ?BAD_REF])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]),
@@ -1138,8 +1088,8 @@ stmtBindByNameFail(#{session := Conn} = TestCtx) ->
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64', 100,
                 0, false, false, null]
         ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(TestCtx, stmt_bindByName, [Stmt, <<"B">>, Var])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1171,10 +1121,8 @@ stmtDefineBadStmt(#{session := Conn} = TestCtx) ->
             [Conn, 'DPI_ORACLE_TYPE_NATIVE_DOUBLE', 'DPI_NATIVE_TYPE_DOUBLE',
                 100, 0, false, false, null]
         ),
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_define, [?BAD_REF, 1, Var])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1192,9 +1140,8 @@ stmtDefineBadPos(#{session := Conn} = TestCtx) ->
                 100, 0, false, false, null]
         ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint pos from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(TestCtx, stmt_define, [Stmt, ?BAD_INT, Var])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1207,9 +1154,8 @@ stmtDefineBadVar(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource var from arg2"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource var from arg2",
         dpiCall(TestCtx, stmt_define, [Stmt, 1, ?BAD_REF])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
@@ -1227,8 +1173,8 @@ stmtDefineFail(#{session := Conn} = TestCtx) ->
                 100, 0, false, false, null]
         ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(TestCtx, stmt_define, [Stmt, 12345, Var])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1250,11 +1196,9 @@ stmtDefineValue(#{session := Conn} = TestCtx) ->
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
-stmtDefineValueBadStmt(#{session := Conn} = TestCtx) -> 
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource statement from arg0"},
+stmtDefineValueBadStmt(TestCtx) -> 
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(
             TestCtx, stmt_defineValue,
             [?BAD_REF, 1, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64',
@@ -1268,9 +1212,8 @@ stmtDefineValueBadPos(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint pos from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(
             TestCtx, stmt_defineValue,
             [Stmt, ?BAD_INT, 'DPI_ORACLE_TYPE_NATIVE_INT',
@@ -1286,8 +1229,8 @@ stmtDefineValueBadOraType(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        #{},
         dpiCall(
             TestCtx, stmt_defineValue,
             [Stmt, 1, "badAtom", 'DPI_NATIVE_TYPE_INT64', 0, false, null]
@@ -1302,8 +1245,8 @@ stmtDefineValueBadNativeType(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "wrong or unsupported dpiNativeType type",
         dpiCall(
             TestCtx, stmt_defineValue,
             [Stmt, 1, 'DPI_ORACLE_TYPE_NATIVE_INT', "badAtom", 0, false, null]
@@ -1318,9 +1261,8 @@ stmtDefineValueBadSize(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint size from arg4"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint size from arg4",
         dpiCall(
             TestCtx, stmt_defineValue,
             [Stmt, 1, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64',
@@ -1336,8 +1278,8 @@ stmtDefineValueBadSizeInBytes(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve bool/atom sizeIsBytes from arg5",
         dpiCall(
             TestCtx, stmt_defineValue,
             [Stmt, 1, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64', 0,
@@ -1353,8 +1295,8 @@ stmtDefineValueFail(#{session := Conn} = TestCtx) ->
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
     dpiCall(TestCtx, stmt_execute, [Stmt, []]),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(
             TestCtx, stmt_defineValue,
             [Stmt, -1, 'DPI_ORACLE_TYPE_NATIVE_INT', 'DPI_NATIVE_TYPE_INT64', 0,
@@ -1370,9 +1312,9 @@ stmtClose(#{session := Conn} = TestCtx) ->
     ),
     ?assertEqual(ok, dpiCall(TestCtx, stmt_close, [Stmt, <<>>])).
 
-stmtCloseBadStmt(#{session := Conn} = TestCtx) -> 
-     ?assertException(
-        error, {error, _File, _Line, _Exception},
+stmtCloseBadStmt(TestCtx) -> 
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_close, [?BAD_REF, <<>>])
     ).
 
@@ -1381,16 +1323,16 @@ stmtCloseBadTag(#{session := Conn} = TestCtx) ->
         TestCtx, conn_prepareStmt,
         [Conn, false, <<"select 1 from dual">>, <<>>]
     ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve string tag from arg1",
         dpiCall(TestCtx, stmt_close, [Stmt, badBinary])
     ),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
 % fails due to wrong reference
 stmtCloseFail(#{session := Conn} = TestCtx) -> 
-     ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource statement from arg0",
         dpiCall(TestCtx, stmt_close, [Conn, <<>>])
     ).
 
@@ -1409,10 +1351,9 @@ varSetNumElementsInArray(#{session := Conn} = TestCtx) ->
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
     dpiCall(TestCtx, var_release, [Var]).
 
-varSetNumElementsInArrayBadVar(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource var from arg0"},
+varSetNumElementsInArrayBadVar(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource var from arg0",
         dpiCall(TestCtx, var_setNumElementsInArray, [?BAD_REF, 100])
     ).
 
@@ -1423,9 +1364,8 @@ varSetNumElementsInArrayBadNumElements(#{session := Conn} = TestCtx) ->
             true, true, null
         ]
     ),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint numElements from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint numElements from arg1",
         dpiCall(TestCtx, var_setNumElementsInArray, [Var, ?BAD_INT])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1439,8 +1379,8 @@ varSetNumElementsInArrayFail(#{session := Conn} = TestCtx) ->
             true, true, null
         ]
     ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve uint numElements from arg1",
         dpiCall(TestCtx, var_setNumElementsInArray, [Var, -1])
     ),
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
@@ -1458,10 +1398,9 @@ varSetFromBytes(#{session := Conn} = TestCtx) ->
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
     dpiCall(TestCtx, var_release, [Var]).
 
-varSetFromBytesBadVar(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource vat from arg0"},
+varSetFromBytesBadVar(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource vat from arg0",
         dpiCall(TestCtx, var_setFromBytes, [?BAD_REF, 0, <<"abc">>])
     ).
 
@@ -1472,9 +1411,8 @@ varSetFromBytesBadPos(#{session := Conn} = TestCtx) ->
             true, true, null
         ]
     ),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve uint pos from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(TestCtx, var_setFromBytes, [Var, ?BAD_INT, <<"abc">>])
     ),
     
@@ -1488,8 +1426,8 @@ varSetFromBytesBadBinary(#{session := Conn} = TestCtx) ->
             true, true, null
         ]
     ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve binary/string value from arg2",
         dpiCall(TestCtx, var_setFromBytes, [Var, 0, badBinary])
     ),
     
@@ -1504,8 +1442,8 @@ varSetFromBytesFail(#{session := Conn} = TestCtx) ->
             true, true, null
         ]
     ),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve uint pos from arg1",
         dpiCall(TestCtx, var_setFromBytes, [Var, -1, <<"abc">>])
     ),
     
@@ -1522,17 +1460,16 @@ varRelease(#{session := Conn} = TestCtx) ->
     [dpiCall(TestCtx, data_release, [X]) || X <- Data],
     ?assertEqual(ok, dpiCall(TestCtx, var_release, [Var])).
 
-varReleaseBadVar(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource var from arg0"},
+varReleaseBadVar(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource var from arg0",
         dpiCall(TestCtx, var_release, [?BAD_REF])
     ).
 
 % fails due to the reference being wrong
-varReleaseFail(#{session := Conn, context := Context} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+varReleaseFail(#{context := Context} = TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource var from arg0",
         dpiCall(TestCtx, var_release, [Context])
     ).
 
@@ -1574,26 +1511,17 @@ queryInfoGet(#{session := Conn} = TestCtx) ->
     dpiCall(TestCtx, queryInfo_delete, [QueryInfoRef]),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
-queryInfoGetBadQueryInfo(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource queryinfo from arg0"},
+queryInfoGetBadQueryInfo(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource queryinfo from arg0",
         dpiCall(TestCtx, queryInfo_get, [?BAD_REF])
     ).
 
-% fails due to getting a completely wrong reference
 queryInfoGetFail(#{session := Conn} = TestCtx) ->
-    Stmt = dpiCall(
-        TestCtx, conn_prepareStmt, 
-        [Conn, false, <<"select 1 from dual">>, <<>>]
-    ),
-    QueryInfoRef = dpiCall(TestCtx, stmt_getQueryInfo, [Stmt, 1]),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource queryinfo from arg0",
         dpiCall(TestCtx, queryInfo_get, [Conn])
-    ),
-    dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
+    ).
 
 queryInfoDelete(#{session := Conn} = TestCtx) ->
     Stmt = dpiCall(
@@ -1604,18 +1532,16 @@ queryInfoDelete(#{session := Conn} = TestCtx) ->
     ?assertEqual(ok, dpiCall(TestCtx, queryInfo_delete, [QueryInfoRef])),
     dpiCall(TestCtx, stmt_close, [Stmt, <<>>]).
 
-queryInfoDeleteBadQueryInfo(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve resource queryInfo from arg0"},
+queryInfoDeleteBadQueryInfo(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource queryInfo from arg0",
         dpiCall(TestCtx, queryInfo_delete, [?BAD_REF])
     ).
 
 % fails due to getting a completely wrong reference
 queryInfoDeleteFail(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource queryInfo from arg0",
         dpiCall(TestCtx, queryInfo_delete, [Conn])
     ).
 
@@ -1631,9 +1557,8 @@ dataSetTimestamp(TestCtx) ->
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetTimestampBadData(TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data/ptr from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(
             TestCtx, data_setTimestamp,
             [?BAD_REF, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -1642,8 +1567,8 @@ dataSetTimestampBadData(TestCtx) ->
 
 dataSetTimestampBadYear(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int year from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve int year from arg1",
         dpiCall(
             TestCtx, data_setTimestamp,
             [Data, ?BAD_INT, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -1653,8 +1578,8 @@ dataSetTimestampBadYear(TestCtx) ->
 
 dataSetTimestampBadMonth(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int month from arg2"},
+    ?ASSERT_EX(
+        "Unable to retrieve int month from arg2",
         dpiCall(
             TestCtx, data_setTimestamp,
             [Data, 1, ?BAD_INT, 3, 4, 5, 6, 7, 8, 9]
@@ -1664,8 +1589,8 @@ dataSetTimestampBadMonth(TestCtx) ->
 
 dataSetTimestampBadDay(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int day from arg3"},
+    ?ASSERT_EX(
+        "Unable to retrieve int day from arg3",
         dpiCall(
             TestCtx, data_setTimestamp,
             [Data, 1, 2, ?BAD_INT, 4, 5, 6, 7, 8, 9]
@@ -1675,8 +1600,8 @@ dataSetTimestampBadDay(TestCtx) ->
 
 dataSetTimestampBadHour(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int hour from arg4"},
+    ?ASSERT_EX(
+        "Unable to retrieve int hour from arg4",
         dpiCall(
             TestCtx, data_setTimestamp,
             [Data, 1, 2, 3, ?BAD_INT, 5, 6, 7, 8, 9]
@@ -1686,9 +1611,8 @@ dataSetTimestampBadHour(TestCtx) ->
 
 dataSetTimestampBadMinute(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve int minute from arg5"},
+    ?ASSERT_EX(
+        "Unable to retrieve int minute from arg5",
         dpiCall(
             TestCtx, data_setTimestamp,
             [Data, 1, 2, 3, 4, ?BAD_INT, 6, 7, 8, 9]
@@ -1698,8 +1622,8 @@ dataSetTimestampBadMinute(TestCtx) ->
 
 dataSetTimestampBadSecond(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int second from arg6"},
+    ?ASSERT_EX(
+        "Unable to retrieve int second from arg6",
         dpiCall(
             TestCtx, data_setTimestamp, [Data, 1, 2, 3, 4, 5, ?BAD_INT, 7, 8, 9]
         )
@@ -1708,9 +1632,8 @@ dataSetTimestampBadSecond(TestCtx) ->
 
 dataSetTimestampBadFSecond(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve int fsecond from arg7"},
+    ?ASSERT_EX(
+        "Unable to retrieve int fsecond from arg7",
         dpiCall(
             TestCtx, data_setTimestamp,
             [Data, 1, 2, 3, 4, 5, 6, ?BAD_INT, 8, 9]
@@ -1720,9 +1643,8 @@ dataSetTimestampBadFSecond(TestCtx) ->
 
 dataSetTimestampBadTZHourOffset(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve int tzHourOffset from arg8"},
+    ?ASSERT_EX(
+        "Unable to retrieve int tzHourOffset from arg8",
         dpiCall(
             TestCtx, data_setTimestamp,
             [Data, 1, 2, 3, 4, 5, 6, 7, ?BAD_INT, 9]
@@ -1732,10 +1654,8 @@ dataSetTimestampBadTZHourOffset(TestCtx) ->
 
 dataSetTimestampBadTZMinuteOffset(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line,
-            "Unable to retrieve int tzMinuteOffset from arg9"},
+    ?ASSERT_EX(
+        "Unable to retrieve int tzMinuteOffset from arg9",
         dpiCall(
             TestCtx, data_setTimestamp,
             [Data, 1, 2, 3, 4, 5, 6, 7, 8, ?BAD_INT]
@@ -1748,8 +1668,8 @@ dataSetTimestampBadTZMinuteOffset(TestCtx) ->
 % Timezone of -22398 hours and 3239 minutes? No problem)
 dataSetTimestampFail(#{session := Conn} = TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(
             TestCtx, data_setTimestamp,
             [Conn, -1234567, 2, 3, 4, 5, 6, 7, -22398, 3239]
@@ -1778,51 +1698,47 @@ dataSetIntervalDS(TestCtx) ->
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetIntervalDSBadData(TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data/ptr from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setIntervalDS, [?BAD_REF, 1, 2, 3, 4, 5])
     ).
 
 dataSetIntervalDSBadDays(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int days from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve int days from arg1",
         dpiCall(TestCtx, data_setIntervalDS, [Data, ?BAD_INT, 2, 3, 4, 5])
     ),
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetIntervalDSBadHours(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int hours from arg2"},
+    ?ASSERT_EX(
+        "Unable to retrieve int hours from arg2",
         dpiCall(TestCtx, data_setIntervalDS, [Data, 1, ?BAD_INT, 3, 4, 5])
     ),
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetIntervalDSBadMinutes(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve int minutes from arg3"},
+    ?ASSERT_EX(
+        "Unable to retrieve int minutes from arg3",
         dpiCall(TestCtx, data_setIntervalDS, [Data, 1, 2, ?BAD_INT, 4, 5])
     ),
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetIntervalDSBadSeconds(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve int seconds from arg4"},
+    ?ASSERT_EX(
+        "Unable to retrieve int seconds from arg4",
         dpiCall(TestCtx, data_setIntervalDS, [Data, 1, 2, 3, ?BAD_INT, 5])
     ),
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetIntervalDSBadFSeconds(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve int fseconds from arg5"},
+    ?ASSERT_EX(
+        "Unable to retrieve int fseconds from arg5",
         dpiCall(TestCtx, data_setIntervalDS, [Data, 1, 2, 3, 4, ?BAD_INT])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -1830,8 +1746,8 @@ dataSetIntervalDSBadFSeconds(TestCtx) ->
 % fails due to the Data ref passed being completely wrong
 dataSetIntervalDSFail(#{session := Conn} = TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setIntervalDS, [Conn, 1, 2, 3, 4, 5])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -1857,24 +1773,23 @@ dataSetIntervalYM(TestCtx) ->
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetIntervalYMBadData(TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data/ptr from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setIntervalYM, [?BAD_REF, 1, 2])
     ).
 
 dataSetIntervalYMBadYears(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int years from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve int years from arg1",
         dpiCall(TestCtx, data_setIntervalYM, [Data, ?BAD_INT, 2])
     ),
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetIntervalYMBadMonths(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int months from arg2"},
+    ?ASSERT_EX(
+        "Unable to retrieve int months from arg2",
         dpiCall(TestCtx, data_setIntervalYM, [Data, 1, ?BAD_INT])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -1882,8 +1797,8 @@ dataSetIntervalYMBadMonths(TestCtx) ->
 % fails due to the Data ref passed being completely wrong
 dataSetIntervalYMFail(#{session := Conn} = TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setIntervalYM, [Conn, 1, 2])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -1909,16 +1824,15 @@ dataSetInt64(TestCtx) ->
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetInt64BadData(TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data/ptr from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setInt64, [?BAD_REF, 1])
     ).
 
 dataSetInt64BadAmount(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, "Unable to retrieve int amount from arg1"},
+    ?ASSERT_EX(
+        "Unable to retrieve int amount from arg1",
         dpiCall(TestCtx, data_setInt64, [Data, ?BAD_INT])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -1926,8 +1840,8 @@ dataSetInt64BadAmount(TestCtx) ->
 % fails due to the Data ref passed being completely wrong
 dataSetInt64Fail(#{session := Conn} = TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setInt64, [Conn, 1])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -1953,16 +1867,15 @@ dataSetBytes(TestCtx) ->
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetBytesBadData(TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data/ptr from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setBytes, [?BAD_REF, <<"my string">>])
     ).
 
 dataSetBytesBadBinary(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve binary data from arg1",
         dpiCall(TestCtx, data_setBytes, [Data, badBinary])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -1970,8 +1883,8 @@ dataSetBytesBadBinary(TestCtx) ->
 % fails due to the Data ref passed being completely wrong
 dataSetBytesFail(#{session := Conn} = TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setBytes, [Conn, <<"my string">>])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -1991,16 +1904,15 @@ dataSetIsNullFalse(TestCtx) ->
     dpiCall(TestCtx, data_release, [Data]).
 
 dataSetIsNullBadData(TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data/ptr from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setIsNull, [?BAD_REF, 1])
     ).
 
 dataSetIsNullBadIsNull(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve bool/atom isNull from arg1",
         dpiCall(TestCtx, data_setIsNull, [Data, "not an atom"])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -2008,8 +1920,8 @@ dataSetIsNullBadIsNull(TestCtx) ->
 % fails due to the Data ref passed being completely wrong
 dataSetIsNullFail(#{session := Conn} = TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_setIsNull, [Conn, 1])
     ),
     dpiCall(TestCtx, data_release, [Data]).
@@ -2247,16 +2159,15 @@ dataGetStmtChange(#{session := Conn} = TestCtx) ->
     dpiCall(TestCtx, stmt_close, [Stmt2, <<>>]).
 
 dataGetBadData(TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data from arg0"},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data from arg0",
         dpiCall(TestCtx, data_get, [?BAD_REF])
     ).
 
 % fails due to completely wrong reference
 dataGetFail(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data from arg0",
         dpiCall(TestCtx, data_get, [Conn])
     ).
 
@@ -2267,35 +2178,33 @@ dataGetUnsupportedType(#{session := Conn} = TestCtx) ->
             1, 0, false, false, null]
     ),
     dpiCall(TestCtx, data_setIsNull, [Data, false]),
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unsupported nativeTypeNum"},
+    ?ASSERT_EX(
+        "Unsupported nativeTypeNum",
         dpiCall(TestCtx, data_get, [Data])
     ),
     dpiCall(TestCtx, data_release, [Data]),
     dpiCall(TestCtx, var_release, [Var]).
 
-dataGetInt64(#{session := Conn} = TestCtx) ->
+dataGetInt64(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
     dpiCall(TestCtx, data_setIsNull, [Data, false]),
     ?assert(is_integer(dpiCall(TestCtx, data_getInt64, [Data]))),
     dpiCall(TestCtx, data_release, [Data]).
 
-dataGetInt64BadData(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data/ptr from arg0"},
+dataGetInt64BadData(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_getInt64, [?BAD_REF])
     ).
 
 % fails due to completely wrong reference
 dataGetInt64Fail(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_getInt64, [Conn])
     ).
 
-dataGetInt64Null(#{session := Conn} = TestCtx) ->
+dataGetInt64Null(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
     dpiCall(TestCtx, data_setIsNull, [Data, true]),
     ?assertEqual(null, dpiCall(TestCtx, data_getInt64, [Data])),
@@ -2326,14 +2235,13 @@ dataGetBytes(#{session := Conn} = TestCtx) ->
     dpiCall(TestCtx, data_release, [Data]),
     dpiCall(TestCtx, var_release, [Var]).
 
-dataGetBytesBadData(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data/ptr from arg0"},
+dataGetBytesBadData(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_getBytes, [?BAD_REF])
     ).
 
-dataGetBytesNull(#{session := Conn} = TestCtx) ->
+dataGetBytesNull(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
     dpiCall(TestCtx, data_setIsNull, [Data, true]),
     ?assertEqual(null, dpiCall(TestCtx, data_getBytes, [Data])),
@@ -2341,28 +2249,25 @@ dataGetBytesNull(#{session := Conn} = TestCtx) ->
 
 % fails due to completely wrong reference
 dataGetBytesFail(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data/ptr from arg0",
         dpiCall(TestCtx, data_getBytes, [Conn])
     ).
 
-dataRelease(#{session := Conn} = TestCtx) ->
+dataRelease(TestCtx) ->
     Data = dpiCall(TestCtx, data_ctor, []),
-    ?assertEqual(ok,
-        dpiCall(TestCtx, data_release, [Data])
-    ).
+    ?assertEqual(ok, dpiCall(TestCtx, data_release, [Data])).
 
-dataReleaseBadData(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error,
-        {error, _File, _Line, "Unable to retrieve resource data from arg0"},
+dataReleaseBadData(TestCtx) ->
+    ?ASSERT_EX(
+        "Unable to retrieve resource data from arg0",
         dpiCall(TestCtx, data_release, [?BAD_REF])
     ).
 
 % fails due to completely wrong reference
 dataReleaseFail(#{session := Conn} = TestCtx) ->
-    ?assertException(
-        error, {error, _File, _Line, _Exception},
+    ?ASSERT_EX(
+        "Unable to retrieve resource data from arg0",
         dpiCall(TestCtx, data_release, [Conn])
     ).
 
@@ -2411,15 +2316,12 @@ setup_connecion(TestCtx) ->
         )
     }.
 
-cleanup(#{safe := Safe, session := Connnnection} = Ctx) ->
+cleanup(#{session := Connnnection} = Ctx) ->
     dpiCall(Ctx, conn_close, [Connnnection, [], <<>>]),
     cleanup(maps:without([session], Ctx));
-cleanup(#{safe := Safe, context := Context} = Ctx) ->
+cleanup(#{context := Context} = Ctx) ->
     dpiCall(Ctx, context_destroy, [Context]),
     cleanup(maps:without([context], Ctx));
-% might as well remove this clause
-cleanup(#{safe := true, node := SlaveNode} = Ctx) ->
-    ok;
 cleanup(_) -> ok.
 
 %-------------------------------------------------------------------------------
@@ -2501,7 +2403,7 @@ cleanup(_) -> ok.
     ?F(stmtExecuteFail),
     ?F(stmtFetch),
     ?F(stmtFetchBadStmt),
-    ?F(stmtFetchFail),
+    ?F(stmtFetchBadRes),
     ?F(stmtGetQueryValue),
     ?F(stmtGetQueryValueBadStmt),
     ?F(stmtGetQueryValueBadPos),
@@ -2644,7 +2546,7 @@ cleanup(_) -> ok.
 
 dpiCall(#{safe := true, node := Node}, F, A) ->
     case dpi:safe(Node, dpi, F, A) of
-        {error, Error} -> error(Error);
+        {error, _, _, _} = Error -> error(Error);
         Result -> Result
     end;
 dpiCall(#{safe := false}, F, A) -> apply(dpi, F, A).
@@ -2671,41 +2573,6 @@ getConfig() ->
             ?debugFmt("~p", [Reason]),
             error(Reason)
     end.
-
-get_column_values(_Safe, _Stmt, ColIdx, Limit) when ColIdx > Limit -> [];
-get_column_values(TestCtx, Stmt, ColIdx, Limit) ->
-    #{data := Data} = dpiCall(TestCtx, stmt_getQueryValue, [Stmt, ColIdx]),
-    [dpiCall(TestCtx, data_get, [Data])
-     | get_column_values(TestCtx, Stmt, ColIdx + 1, Limit)].
-
-% gets a value out of a fetched set, compares it using an assertation,
-% then cleans is up again
-assert_getQueryValue(TestCtx, Stmt, Index, Value) ->
-    #{data := QueryValueRef} =
-        dpiCall(TestCtx, stmt_getQueryValue, [Stmt, Index]),
-    ?assertEqual(Value, dpiCall(TestCtx, data_get, [QueryValueRef])),
-	dpiCall(TestCtx, data_release, [QueryValueRef]).
-
-
-assert_getQueryInfo(TestCtx, Stmt, Index, Value, Atom) ->
-    QueryInfoRef = dpiCall(TestCtx, stmt_getQueryInfo, [Stmt, Index]),
-    ?assertEqual(
-        Value, maps:get(Atom, dpiCall(TestCtx, queryInfo_get, [QueryInfoRef]))
-    ),
-	dpiCall(TestCtx, queryInfo_delete, [QueryInfoRef]).
-
-extract_getQueryValue(TestCtx, Stmt, Index) ->
-    #{data := QueryValueRef} =
-        dpiCall(TestCtx, stmt_getQueryValue, [Stmt, Index]),
-    Result = dpiCall(TestCtx, data_get, [QueryValueRef]),
-	dpiCall(TestCtx, data_release, [QueryValueRef]),
-    Result.
-
-extract_getQueryInfo(TestCtx, Stmt, Index, Atom) ->
-    QueryInfoRef = dpiCall(TestCtx, stmt_getQueryInfo, [Stmt, Index]),
-    Result = maps:get(Atom, dpiCall(TestCtx, queryInfo_get, [QueryInfoRef])),
-	dpiCall(TestCtx, queryInfo_delete, [QueryInfoRef]),
-    Result.
 
 %-------------------------------------------------------------------------------
 % Unit Tests


### PR DESCRIPTION
This PR is to adapt to error interface change to PR #109 
Test erlang compile warning fixes
Dead code in eunit test removed
added missing in file and line into to `dpiContext_create` 

**TBD** by @KarlKeiser 
* Please fix the following two error message in this branch (replace the text with something meaning ful)
https://github.com/K2InformaticsGmbH/oranif/blob/6e3deec7656e93f2873d0f6113c38319e8bb950b/test/oranif_eunit.erl#L444 https://github.com/K2InformaticsGmbH/oranif/blob/6e3deec7656e93f2873d0f6113c38319e8bb950b/test/oranif_eunit.erl#L576
* I removed some dead code in erlang eunit, please make sure that it did **NOT** effect coverage!

@acautin after you merge this PR to yours the travis test should go through again.