### PR TITLE
fixes travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 
 group: edge
 
+dist: trusty
+
 services:
  - docker
 


### PR DESCRIPTION
erlang 20.2 is available only on dist: trusty